### PR TITLE
Add placeholder loading with fade transition

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,17 @@
         const booksPerPage = 24;
         let books = [];
         let filteredBooks = [];
+
+        function loadImage(imgElem) {
+            const src = imgElem.getAttribute('data-src');
+            if (!src) return;
+            const img = new Image();
+            img.src = src;
+            img.onload = () => {
+                imgElem.src = src;
+                imgElem.classList.add('loaded');
+            };
+        }
     
         async function fetchBooks() {
             try {
@@ -66,7 +77,7 @@
 
                 link.innerHTML = `
                     <div class="book-img-wrapper">
-                        <img src="${book.imagen}" alt="${book.titulo}">
+                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img" width="180" height="240">
                         ${book.vendido ? '<span class="sold-badge">VENDIDO</span>' : ''}
                     </div>
                     <h3>${book.titulo}</h3>
@@ -78,6 +89,8 @@
 
                 bookCard.appendChild(link);
                 booksContainer.appendChild(bookCard);
+                const imgElem = link.querySelector('img.lazy-img');
+                loadImage(imgElem);
             });
 
     

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
     <meta property="og:type" content="website">
     <link rel="canonical" href="https://morfemalibreria.web.app/">
     <link rel="stylesheet" href="styles.css">
+    <link rel="preload" href="placeholder.png" as="image">
     <link rel="icon" href="logo.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
     
@@ -27,12 +28,21 @@
         function loadImage(imgElem) {
             const src = imgElem.getAttribute('data-src');
             if (!src) return;
-            const img = new Image();
-            img.src = src;
-            img.onload = () => {
-                imgElem.src = src;
-                imgElem.classList.add('loaded');
-            };
+
+            function startLoading() {
+                const realImg = new Image();
+                realImg.src = src;
+                realImg.onload = () => {
+                    imgElem.src = src;
+                    imgElem.classList.add('loaded');
+                };
+            }
+
+            if (imgElem.complete) {
+                startLoading();
+            } else {
+                imgElem.addEventListener('load', startLoading, { once: true });
+            }
         }
     
         async function fetchBooks() {
@@ -77,7 +87,7 @@
 
                 link.innerHTML = `
                     <div class="book-img-wrapper">
-                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img" width="180" height="240">
+                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img" width="180" height="240" loading="lazy">
                         ${book.vendido ? '<span class="sold-badge">VENDIDO</span>' : ''}
                     </div>
                     <h3>${book.titulo}</h3>

--- a/public/libro.html
+++ b/public/libro.html
@@ -18,6 +18,17 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
     <link rel="icon" href="logo.png">
     <script>
+        function loadImage(imgElem) {
+            const src = imgElem.getAttribute('data-src');
+            if (!src) return;
+            const img = new Image();
+            img.src = src;
+            img.onload = () => {
+                imgElem.src = src;
+                imgElem.classList.add('loaded');
+            };
+        }
+
         async function fetchBook() {
             try {
                 const response = await fetch('books.json');
@@ -43,7 +54,7 @@
             container.innerHTML = `
                 <div class="book-detail">
                     <div class="book-img-wrapper">
-                        <img src="${book.imagen}" alt="${book.titulo}">
+                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img">
                         ${book.vendido ? '<span class="sold-badge">VENDIDO</span>' : ''}
                     </div>
                     <h3>${book.titulo}</h3>
@@ -52,6 +63,8 @@
                     <p><strong>Estado:</strong> ${book.estado}</p>
                     <p><strong>Precio:</strong> ${book.precio}</p>
                 </div>`;
+            const imgElem = container.querySelector('img.lazy-img');
+            loadImage(imgElem);
         }
 
         document.addEventListener('DOMContentLoaded', fetchBook);

--- a/public/libro.html
+++ b/public/libro.html
@@ -15,18 +15,28 @@
     <meta property="og:type" content="book">
     <link rel="canonical" href="https://morfemalibreria.web.app/libro.html">
     <link rel="stylesheet" href="styles.css">
+    <link rel="preload" href="placeholder.png" as="image">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
     <link rel="icon" href="logo.png">
     <script>
         function loadImage(imgElem) {
             const src = imgElem.getAttribute('data-src');
             if (!src) return;
-            const img = new Image();
-            img.src = src;
-            img.onload = () => {
-                imgElem.src = src;
-                imgElem.classList.add('loaded');
-            };
+
+            function startLoading() {
+                const realImg = new Image();
+                realImg.src = src;
+                realImg.onload = () => {
+                    imgElem.src = src;
+                    imgElem.classList.add('loaded');
+                };
+            }
+
+            if (imgElem.complete) {
+                startLoading();
+            } else {
+                imgElem.addEventListener('load', startLoading, { once: true });
+            }
         }
 
         async function fetchBook() {
@@ -54,7 +64,7 @@
             container.innerHTML = `
                 <div class="book-detail">
                     <div class="book-img-wrapper">
-                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img">
+                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img" loading="lazy">
                         ${book.vendido ? '<span class="sold-badge">VENDIDO</span>' : ''}
                     </div>
                     <h3>${book.titulo}</h3>

--- a/public/styles.css
+++ b/public/styles.css
@@ -146,6 +146,32 @@ body {
 /* Badge rojo de "VENDIDO" */
 .book-img-wrapper {
     position: relative;
+    background: url('placeholder.png') center center / cover no-repeat;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.book-card .book-img-wrapper {
+    width: 180px;
+    height: 240px;
+}
+
+.book-detail .book-img-wrapper {
+    max-width: 350px;
+    margin: 0 auto 20px auto;
+}
+
+.lazy-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+.lazy-img.loaded {
+    opacity: 1;
 }
 
 .sold-badge {


### PR DESCRIPTION
## Summary
- use placeholder for book images and fade in real cover image once loaded
- add placeholder/fade-in logic to `libro.html`
- style wrapper for placeholder image

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687558454e6c8322b97528a77a99c7af