### PR TITLE
Fix single book per row on mobile

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -301,7 +301,7 @@ body {
 }
 @media (max-width: 500px) {
     .books {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(1, 1fr);
     }
 }
 @media (max-width: 350px) {


### PR DESCRIPTION
## Summary
- display one book per row on screens under 500px wide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687571935bb88322ae0c1d546b34ab84