### PR TITLE
Fix metadata and remove binary favicon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,13 +10,13 @@
     <meta name="robots" content="index, follow">
     <meta property="og:title" content="Morfema - Librería">
     <meta property="og:description" content="Explorá el catálogo de libros usados de Morfema.">
-    <meta property="og:image" content="logo400x400fondo.png">
-    <meta property="og:url" content="https://morfemalibreria.web.app/">
+    <meta property="og:image" content="https://morfemalibreria.com.ar/logo400x400fondo.png">
+    <meta property="og:url" content="https://morfemalibreria.com.ar/">
     <meta property="og:type" content="website">
-    <link rel="canonical" href="https://morfemalibreria.web.app/">
+    <link rel="canonical" href="https://morfemalibreria.com.ar/">
     <link rel="stylesheet" href="styles.css">
     <link rel="preload" href="placeholder.png" as="image">
-    <link rel="icon" href="logo.png">
+    <link rel="icon" href="/favicon.png" type="image/png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
     
     <script>

--- a/public/lee-gratis.html
+++ b/public/lee-gratis.html
@@ -6,7 +6,7 @@
     <title>Leé gratis - Morfema</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    <link rel="icon" href="logo.png">
+    <link rel="icon" href="/favicon.png" type="image/png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4WKGMKCLQH"></script>
     <script>

--- a/public/libro.html
+++ b/public/libro.html
@@ -10,14 +10,14 @@
     <meta name="robots" content="index, follow">
     <meta property="og:title" content="Morfema - Libro">
     <meta property="og:description" content="Detalles del libro disponible en Morfema Librería">
-    <meta property="og:image" content="logo400x400fondo.png">
-    <meta property="og:url" content="https://morfemalibreria.web.app/libro.html">
+    <meta property="og:image" content="https://morfemalibreria.com.ar/logo400x400fondo.png">
+    <meta property="og:url" content="https://morfemalibreria.com.ar/libro.html">
     <meta property="og:type" content="book">
-    <link rel="canonical" href="https://morfemalibreria.web.app/libro.html">
+    <link rel="canonical" href="https://morfemalibreria.com.ar/libro.html">
     <link rel="stylesheet" href="styles.css">
     <link rel="preload" href="placeholder.png" as="image">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    <link rel="icon" href="logo.png">
+    <link rel="icon" href="/favicon.png" type="image/png">
     <script>
         function loadImage(imgElem) {
             const src = imgElem.getAttribute('data-src');

--- a/public/talleres.html
+++ b/public/talleres.html
@@ -6,7 +6,7 @@
     <title>Talleres - Morfema</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    <link rel="icon" href="logo.png">
+    <link rel="icon" href="/favicon.png" type="image/png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4WKGMKCLQH"></script>
     <script>

--- a/public/vende.html
+++ b/public/vende.html
@@ -6,7 +6,7 @@
     <title>Vendé tus libros - Morfema</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    <link rel="icon" href="logo.png">
+    <link rel="icon" href="/favicon.png" type="image/png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4WKGMKCLQH"></script>
     <script>


### PR DESCRIPTION
## Summary
- replace references to `morfemalibreria.web.app` with `morfemalibreria.com.ar`
- use `/favicon.png` path in page heads
- remove `favicon.png` to avoid binary diff

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68764d0e558c8322b29cc6b0e18980c8