### PR TITLE
Fix overlapping book cards on desktop

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -108,6 +108,7 @@ body {
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
     text-align: center;
     width: 100%;
+    box-sizing: border-box;
 }
 .book-card h3 {
     overflow-wrap: anywhere;


### PR DESCRIPTION
## Summary
- ensure `.book-card` uses border-box sizing so padding doesn't exceed grid width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68766f12f5688322a963bc939a1b6b83