### PR TITLE
Fix npm test by adding package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "morfemalibreria",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/test.js"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const assert = require('assert');
+
+try {
+  const content = fs.readFileSync('public/books.json', 'utf8');
+  const data = JSON.parse(content);
+  assert.ok(Array.isArray(data), 'books.json should contain an array');
+  console.log('books.json parsed successfully.');
+} catch (err) {
+  console.error('Test failed:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `package.json` with a simple test script
- include a JSON validation test for `books.json`

## Testing
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee1b603bc8322befff014de30f989