### PR TITLE
Add Prettier formatting tooling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ npm test
 
 Este comando verifica que `public/books.json` pueda analizarse correctamente.
 
+## Formato de código
+
+Utiliza [Prettier](https://prettier.io/) para mantener el estilo consistente. Ejecuta:
+
+```bash
+npm run format
+```
+
+Esto formatea los archivos HTML, CSS y JavaScript dentro de `public/`.
+
 ## Despliegue en Firebase Hosting
 
 1. Inicia sesión con tu cuenta de Firebase si no lo has hecho:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "morfemalibreria",
       "version": "1.0.0",
       "devDependencies": {
-        "eslint": "^8.0.0"
+        "eslint": "^8.0.0",
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -992,6 +993,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "scripts": {
     "test": "node test/test.js",
-    "lint": "eslint public/**/*.js test/**/*.js"
+    "lint": "eslint public/**/*.js test/**/*.js",
+    "format": "prettier --write \"public/**/*.{js,css,html}\""
   },
   "devDependencies": {
-    "eslint": "^8.0.0"
+    "eslint": "^8.0.0",
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- add Prettier dev dependency
- define Prettier rules
- provide npm `format` script
- document formatting instructions

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687fa74110b88322a368de0eee3b8907