### PR TITLE
Remove WhatsApp links from footer

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -16,13 +16,11 @@
         <a href="index.html" class="filter-button">Volver al inicio</a>
     </div>
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
     <script src="navbar.js"></script>
 </body>

--- a/public/catalogo.html
+++ b/public/catalogo.html
@@ -245,13 +245,11 @@
     </div>
     
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
 <script src="navbar.js"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -297,13 +297,11 @@
         </div>
     </div>
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
 <script src="navbar.js"></script>
 </body>

--- a/public/lee-gratis.html
+++ b/public/lee-gratis.html
@@ -24,13 +24,11 @@
         Próximamente
     </div>
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
 <script src="navbar.js"></script>
 </body>

--- a/public/libro.html
+++ b/public/libro.html
@@ -109,13 +109,11 @@
     <div id="navbar" data-current="CATÁLOGO USADOS"></div>
     <div class="container" id="bookContainer"></div>
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
 <script src="navbar.js"></script>
 </body>

--- a/public/quienes-somos.html
+++ b/public/quienes-somos.html
@@ -24,13 +24,11 @@
         Próximamente
     </div>
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
 <script src="navbar.js"></script>
 </body>

--- a/public/talleres.html
+++ b/public/talleres.html
@@ -24,13 +24,11 @@
         Próximamente
     </div>
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
 <script src="navbar.js"></script>
 </body>

--- a/public/vende.html
+++ b/public/vende.html
@@ -24,13 +24,11 @@
         Próximamente
     </div>
     <div class="footer">
-        <p>Contacto:</p>
-        <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-instagram"></i> Instagram
-        </a>
-        <a href="https://wa.me/541135752748" target="_blank" rel="noopener noreferrer">
-            <i class="fab fa-whatsapp"></i> WhatsApp
-        </a>
+        <p>Contacto:
+            <a href="https://www.instagram.com/morfemalibreria" target="_blank" rel="noopener noreferrer">
+                <i class="fab fa-instagram"></i> Instagram
+            </a>
+        </p>
     </div>
 <script src="navbar.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- update footer of all pages to remove WhatsApp contact
- keep Instagram link inline in the footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fb0e5e6a083229ca415d3d33f4ff0