### PR TITLE
Add explicit img dimensions

### DIFF
--- a/public/catalogo.html
+++ b/public/catalogo.html
@@ -213,7 +213,7 @@
     <div class="container">
         <div class="header">Morfema - Librería</div>
         <div class="logo-container">
-            <img src="logo.png" alt="Morfema" class="logo">
+            <img src="logo.png" alt="Morfema" class="logo" width="1080" height="460">
         </div>
         <div class="filters-container-wrapper">
             <div class="filters-container">

--- a/public/index.html
+++ b/public/index.html
@@ -125,7 +125,7 @@
                         <a href="libro.html?id=${libro.id}&titulo=${titleParam}" class="book-link">
                             <div class="book-card ${libro.vendido ? 'sold' : ''}">
                                 <div class="book-img-wrapper">
-                                    <img src="${libro.imagen}" alt="${libro.titulo}" loading="lazy">
+                                    <img src="${libro.imagen}" alt="${libro.titulo}" loading="lazy" width="600" height="800">
                                 </div>
                                 <h3>${libro.titulo}</h3>
                                 <p><strong>Autor:</strong> ${libro.autor}</p>
@@ -191,7 +191,7 @@
                         <a href="libro.html?id=${libro.id}&titulo=${titleParam}" class="book-link">
                             <div class="book-card">
                                 <div class="book-img-wrapper">
-                                    <img src="${libro.imagen}" alt="${libro.titulo}" loading="lazy">
+                                    <img src="${libro.imagen}" alt="${libro.titulo}" loading="lazy" width="600" height="800">
                                 </div>
                                 <h3>${libro.titulo}</h3>
                                 <p><strong>Autor:</strong> ${libro.autor}</p>
@@ -276,7 +276,7 @@
     <div class="container">
         <div class="header">Morfema - Librería</div>
         <div class="logo-container">
-            <img src="logo.png" alt="Morfema" class="logo">
+            <img src="logo.png" alt="Morfema" class="logo" width="1080" height="460">
         </div>
         <h2 class="novedades-title">NOVEDADES</h2>
         <div class="carousel" id="novedades-carousel">

--- a/public/libro.html
+++ b/public/libro.html
@@ -79,7 +79,7 @@
             container.innerHTML = `
                 <div class="book-detail">
                     <div class="book-img-wrapper">
-                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img" loading="lazy">
+                        <img src="placeholder.png" data-src="${book.imagen}" alt="${book.titulo}" class="lazy-img" loading="lazy" width="600" height="800">
                         ${book.novedad ? '<span class="new-badge">NOVEDAD</span>' : ''}
                         ${book.vendido ? '<span class="sold-badge">VENDIDO</span>' : ''}
                     </div>


### PR DESCRIPTION
## Summary
- define width and height for logo images
- include dimensions when book images are injected on index and book pages

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fb32392f48322ade2d5ed4a505dec