### PR TITLE
Add sitemap generation

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,8 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-# Temporarily disable build step
-# - run: npm ci && npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - run: npm ci
+      - run: node generate-sitemap.js
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,8 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-# Temporarily disable build step
-# - run: npm ci && npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - run: npm ci
+      - run: node generate-sitemap.js
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,5 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm test
+      - run: node generate-sitemap.js
+      - run: git diff --quiet public/sitemap.xml

--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const publicDir = path.join(__dirname, 'public');
+const baseUrl = process.env.SITEMAP_BASE_URL || 'https://morfemalibreria.com.ar';
+
+const exclude = new Set(['404.html', 'navbar.html', 'gtm.html']);
+
+const pages = fs
+  .readdirSync(publicDir)
+  .filter((f) => f.endsWith('.html') && !exclude.has(f));
+
+// Make sure index.html appears first for nicer ordering
+pages.sort((a, b) => {
+  if (a === 'index.html') return -1;
+  if (b === 'index.html') return 1;
+  return a.localeCompare(b);
+});
+
+const urls = pages.map((file) => {
+  if (file === 'index.html') {
+    return `${baseUrl}/`;
+  }
+  return `${baseUrl}/${file}`;
+});
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls
+  .map((u) => `  <url><loc>${u}</loc></url>`)
+  .join('\n')}\n</urlset>\n`;
+
+fs.writeFileSync(path.join(publicDir, 'sitemap.xml'), xml);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "morfemalibreria",
       "version": "1.0.0",
       "devDependencies": {
-        "eslint": "^8.0.0",
+        "eslint": "8.57.0",
         "http-server": "^14.1.1",
         "prettier": "^3.6.2"
       }
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -77,14 +77,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
+        "@humanwhocodes/object-schema": "^2.0.2",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
@@ -490,8 +490,8 @@
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
     "test": "node test/test.js",
     "lint": "eslint public/**/*.js test/**/*.js",
     "format": "prettier --write \"public/**/*.{js,css,html}\"",
-    "start": "npx http-server public"
+    "start": "npx http-server public",
+    "generate:sitemap": "node generate-sitemap.js"
   },
   "devDependencies": {
-    "eslint": "^8.0.0",
+    "eslint": "8.57.0",
     "http-server": "^14.1.1",
     "prettier": "^3.6.2"
   }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://morfemalibreria.com.ar/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://morfemalibreria.com.ar/</loc></url>
+  <url><loc>https://morfemalibreria.com.ar/catalogo.html</loc></url>
+  <url><loc>https://morfemalibreria.com.ar/lee-gratis.html</loc></url>
+  <url><loc>https://morfemalibreria.com.ar/libro.html</loc></url>
+  <url><loc>https://morfemalibreria.com.ar/quienes-somos.html</loc></url>
+  <url><loc>https://morfemalibreria.com.ar/talleres.html</loc></url>
+  <url><loc>https://morfemalibreria.com.ar/vende.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- automatically generate `public/sitemap.xml`
- expose sitemap in `public/robots.txt`
- run sitemap generation in CI workflows
- pin eslint to v8 for compatibility

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run generate:sitemap`

------
https://chatgpt.com/codex/tasks/task_e_687fb99a07f88322bbd01e13a622c3d3