### PR TITLE
Add SEO meta tags

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -1,10 +1,31 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>404 - Página no encontrada</title>
+    <meta name="description" content="La página solicitada no existe." />
+    <meta name="robots" content="noindex" />
+    <meta property="og:title" content="404 - Página no encontrada" />
+    <meta property="og:description" content="La página solicitada no existe." />
+    <meta
+      property="og:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
+    <meta property="og:url" content="https://morfemalibreria.com.ar/404.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_AR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="404 - Página no encontrada" />
+    <meta
+      name="twitter:description"
+      content="La página solicitada no existe."
+    />
+    <meta
+      name="twitter:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
     <link rel="stylesheet" href="styles.css" />
     <link
       rel="stylesheet"
@@ -12,6 +33,14 @@
     />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/404.html" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Página no encontrada",
+        "url": "https://morfemalibreria.com.ar/404.html"
+      }
+    </script>
   </head>
   <body>
     <div id="navbar" data-current="404"></div>

--- a/src/catalogo.html
+++ b/src/catalogo.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>
@@ -26,6 +26,17 @@
     />
     <meta property="og:url" content="https://morfemalibreria.com.ar/" />
     <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_AR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Morfema - Librería" />
+    <meta
+      name="twitter:description"
+      content="Explorá el catálogo de libros usados de Morfema."
+    />
+    <meta
+      name="twitter:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
     <link rel="canonical" href="/catalogo.html" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="preload" href="placeholder.png" as="image" />
@@ -34,6 +45,14 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "Catálogo Morfema",
+        "url": "https://morfemalibreria.com.ar/catalogo.html"
+      }
+    </script>
 
     <script>
       let currentPage = 1;

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>
@@ -26,6 +26,17 @@
     />
     <meta property="og:url" content="https://morfemalibreria.com.ar/" />
     <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_AR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Morfema - Librería" />
+    <meta
+      name="twitter:description"
+      content="Explorá las novedades de Morfema"
+    />
+    <meta
+      name="twitter:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
     <link rel="canonical" href="/" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="preload" href="placeholder.png" as="image" />
@@ -34,6 +45,14 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BookStore",
+        "name": "Morfema Librería",
+        "url": "https://morfemalibreria.com.ar/"
+      }
+    </script>
     <style>
       .carousel {
         position: relative;

--- a/src/lee-gratis.html
+++ b/src/lee-gratis.html
@@ -1,10 +1,40 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Leé gratis - Morfema</title>
+    <meta
+      name="description"
+      content="Recursos gratuitos de lectura en Morfema"
+    />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:title" content="Leé gratis - Morfema" />
+    <meta
+      property="og:description"
+      content="Recursos gratuitos de lectura en Morfema"
+    />
+    <meta
+      property="og:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
+    <meta
+      property="og:url"
+      content="https://morfemalibreria.com.ar/lee-gratis.html"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_AR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Leé gratis - Morfema" />
+    <meta
+      name="twitter:description"
+      content="Recursos gratuitos de lectura en Morfema"
+    />
+    <meta
+      name="twitter:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
     <link rel="stylesheet" href="styles.css" />
     <link
       rel="stylesheet"
@@ -12,6 +42,14 @@
     />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/lee-gratis.html" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Leé gratis - Morfema",
+        "url": "https://morfemalibreria.com.ar/lee-gratis.html"
+      }
+    </script>
     <!-- Google tag (gtag.js) -->
     <script
       async

--- a/src/libro.html
+++ b/src/libro.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>
@@ -29,6 +29,17 @@
       content="https://morfemalibreria.com.ar/libro.html"
     />
     <meta property="og:type" content="book" />
+    <meta property="og:locale" content="es_AR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Morfema - Libro" />
+    <meta
+      name="twitter:description"
+      content="Detalles del libro disponible en Morfema Librería"
+    />
+    <meta
+      name="twitter:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
     <link rel="canonical" href="/libro.html" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="preload" href="placeholder.png" as="image" />
@@ -37,6 +48,7 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
+    <script type="application/ld+json" id="book-schema"></script>
     <script>
       function loadImage(imgElem) {
         const src = imgElem.getAttribute('data-src');
@@ -84,6 +96,16 @@
             if (canonical) canonical.setAttribute('href', url);
             const ogUrl = document.querySelector('meta[property="og:url"]');
             if (ogUrl) ogUrl.setAttribute('content', url);
+            const ld = {
+              '@context': 'https://schema.org',
+              '@type': 'Book',
+              name: book.titulo,
+              author: book.autor,
+              image: book.imagen,
+              url: url,
+            };
+            const ldScript = document.getElementById('book-schema');
+            if (ldScript) ldScript.textContent = JSON.stringify(ld);
           } else {
             document.getElementById('bookContainer').textContent =
               'Libro no encontrado.';

--- a/src/quienes-somos.ejs
+++ b/src/quienes-somos.ejs
@@ -1,6 +1,35 @@
 <%- include('templates/layout', { title: 'Quiénes somos - Morfema', current:
 'QUIÉNES SOMOS', headExtra: `
+<meta name="description" content="Conocé más sobre Morfema Librería" />
+<meta name="robots" content="index, follow" />
+<meta property="og:title" content="Quiénes somos - Morfema" />
+<meta property="og:description" content="Conocé más sobre Morfema Librería" />
+<meta
+  property="og:image"
+  content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+/>
+<meta
+  property="og:url"
+  content="https://morfemalibreria.com.ar/quienes-somos.html"
+/>
+<meta property="og:type" content="website" />
+<meta property="og:locale" content="es_AR" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Quiénes somos - Morfema" />
+<meta name="twitter:description" content="Conocé más sobre Morfema Librería" />
+<meta
+  name="twitter:image"
+  content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+/>
 <link rel="canonical" href="/quienes-somos.html" />
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Quiénes somos - Morfema",
+    "url": "https://morfemalibreria.com.ar/quienes-somos.html"
+  }
+</script>
 <!-- Google tag (gtag.js) -->
 <script
   async

--- a/src/talleres.html
+++ b/src/talleres.html
@@ -1,10 +1,40 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talleres - Morfema</title>
+    <meta
+      name="description"
+      content="Próximos talleres y actividades culturales"
+    />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:title" content="Talleres - Morfema" />
+    <meta
+      property="og:description"
+      content="Próximos talleres y actividades culturales"
+    />
+    <meta
+      property="og:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
+    <meta
+      property="og:url"
+      content="https://morfemalibreria.com.ar/talleres.html"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_AR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Talleres - Morfema" />
+    <meta
+      name="twitter:description"
+      content="Próximos talleres y actividades culturales"
+    />
+    <meta
+      name="twitter:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
     <link rel="stylesheet" href="styles.css" />
     <link
       rel="stylesheet"
@@ -12,6 +42,14 @@
     />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/talleres.html" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Talleres - Morfema",
+        "url": "https://morfemalibreria.com.ar/talleres.html"
+      }
+    </script>
     <!-- Google tag (gtag.js) -->
     <script
       async

--- a/src/templates/layout.ejs
+++ b/src/templates/layout.ejs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>

--- a/src/vende.html
+++ b/src/vende.html
@@ -1,10 +1,40 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <script src="load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vendé tus libros - Morfema</title>
+    <meta
+      name="description"
+      content="Cómo vender tus libros usados en Morfema"
+    />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:title" content="Vendé tus libros - Morfema" />
+    <meta
+      property="og:description"
+      content="Cómo vender tus libros usados en Morfema"
+    />
+    <meta
+      property="og:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
+    <meta
+      property="og:url"
+      content="https://morfemalibreria.com.ar/vende.html"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_AR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Vendé tus libros - Morfema" />
+    <meta
+      name="twitter:description"
+      content="Cómo vender tus libros usados en Morfema"
+    />
+    <meta
+      name="twitter:image"
+      content="https://morfemalibreria.com.ar/logo400x400fondo.png"
+    />
     <link rel="stylesheet" href="styles.css" />
     <link
       rel="stylesheet"
@@ -12,6 +42,14 @@
     />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/vende.html" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Vendé tus libros - Morfema",
+        "url": "https://morfemalibreria.com.ar/vende.html"
+      }
+    </script>
     <!-- Google tag (gtag.js) -->
     <script
       async


### PR DESCRIPTION
## Summary
- improve SEO across all site pages
- add OpenGraph/Twitter tags and locale info
- include structured data placeholders
- set document language to es-AR for Spanish (Argentina)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fe026ca9883229c461edad3c65b75