### PR TITLE
Fix book title line spacing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -116,8 +116,8 @@ body {
     font-family: 'Merriweather', serif;
     font-size: 18px;
     font-weight: 700;
-    line-height: 1.2;
-    min-height: 2.4em;
+    line-height: 1.3;
+    min-height: 2.6em;
     overflow: hidden;
     display: -webkit-box;
     -webkit-line-clamp: 2;


### PR DESCRIPTION
## Summary
- relax line-height in `.book-card` titles to avoid overlapping text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814094321c8322b3f5305a2642b998