### PR TITLE
Increase carousel title font size

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -90,7 +90,7 @@
         width: 378px;
       }
       .carousel-slide .book-card h3 {
-        font-size: 16px;
+        font-size: 21px;
       }
       .carousel-slide .book-card p {
         font-size: 12px;


### PR DESCRIPTION
## Summary
- bump carousel book title font size from 16px to 21px in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688189d7f7748322868bfb7436901268