### PR TITLE
Refactor reseñas urls

### DIFF
--- a/build.js
+++ b/build.js
@@ -13,32 +13,33 @@ fs.mkdirSync(distDir, { recursive: true });
 // copy static assets from public
 fs.cpSync(publicDir, distDir, { recursive: true });
 
-// render ejs templates and copy html files
-for (const file of fs.readdirSync(srcDir)) {
-  if (file.endsWith('.ejs')) {
-    const template = fs.readFileSync(path.join(srcDir, file), 'utf8');
-    const html = ejs.render(template, {}, { filename: path.join(srcDir, file) });
-    const outFile = file.replace(/\.ejs$/, '.html');
-    fs.writeFileSync(path.join(distDir, outFile), html);
-  } else if (file.endsWith('.html')) {
-    fs.copyFileSync(path.join(srcDir, file), path.join(distDir, file));
+function processDir(srcPath, outPath) {
+  fs.mkdirSync(outPath, { recursive: true });
+  for (const entry of fs.readdirSync(srcPath, { withFileTypes: true })) {
+    const srcFile = path.join(srcPath, entry.name);
+    const outFile = path.join(outPath, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'templates') continue;
+      processDir(srcFile, outFile);
+    } else if (entry.name.endsWith('.ejs')) {
+      const template = fs.readFileSync(srcFile, 'utf8');
+      const html = ejs.render(template, {}, { filename: srcFile });
+      fs.writeFileSync(outFile.replace(/\.ejs$/, '.html'), html);
+    } else if (entry.name.endsWith('.html')) {
+      fs.copyFileSync(srcFile, outFile);
+    } else if (entry.name.endsWith('.js')) {
+      esbuild.buildSync({
+        entryPoints: [srcFile],
+        outfile: outFile,
+        bundle: false,
+        minify: true,
+        format: 'iife',
+      });
+    } else if (entry.name.endsWith('.css')) {
+      const css = fs.readFileSync(srcFile, 'utf8');
+      fs.writeFileSync(outFile, css);
+    }
   }
 }
 
-// build js and css
-const jsFiles = fs.readdirSync(srcDir).filter(f => f.endsWith('.js'));
-for (const file of jsFiles) {
-  esbuild.buildSync({
-    entryPoints: [path.join(srcDir, file)],
-    outfile: path.join(distDir, file),
-    bundle: false,
-    minify: true,
-    format: 'iife',
-  });
-}
-
-const cssFiles = fs.readdirSync(srcDir).filter(f => f.endsWith('.css'));
-for (const file of cssFiles) {
-  const css = fs.readFileSync(path.join(srcDir, file), 'utf8');
-  fs.writeFileSync(path.join(distDir, file), css);
-}
+processDir(srcDir, distDir);

--- a/src/navbar.html
+++ b/src/navbar.html
@@ -6,7 +6,7 @@
     <a href="catalogo.html">CATÁLOGO USADOS</a>
     <a href="vende.html">VENDÉ TUS LIBROS CON NOSOTROS</a>
     <a href="lee-gratis.html">LEÉ GRATIS</a>
-    <a href="resenas.html">RESEÑAS</a>
+    <a href="resenas/">RESEÑAS</a>
     <a href="talleres.html">TALLERES</a>
     <a href="quienes-somos.html">QUIÉNES SOMOS</a>
   </div>

--- a/src/resenas/garcia_marquez_los_sims.html
+++ b/src/resenas/garcia_marquez_los_sims.html
@@ -2,7 +2,7 @@
 <html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
-    <script src="load-gtm.js"></script>
+    <script src="../load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cien años de soledad - Reseña | Morfema</title>
     <meta name="description" content="Reseña de Cien años de soledad" />
@@ -15,7 +15,7 @@
     />
     <meta
       property="og:url"
-      content="https://morfemalibreria.com.ar/resena-cien-anos.html"
+      content="https://morfemalibreria.com.ar/resenas/garcia_marquez_los_sims.html"
     />
     <meta property="og:type" content="article" />
     <meta property="og:locale" content="es_AR" />
@@ -26,7 +26,7 @@
       name="twitter:image"
       content="https://morfemalibreria.com.ar/logo400x400fondo.png"
     />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="../styles.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
@@ -35,14 +35,14 @@
       href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&family=Montserrat:wght@900&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="favicon.ico" type="image/x-icon" />
-    <link rel="canonical" href="/resena-cien-anos.html" />
+    <link rel="icon" href="../favicon.ico" type="image/x-icon" />
+    <link rel="canonical" href="/resenas/garcia_marquez_los_sims.html" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "Review",
         "name": "Cien años de soledad - Reseña",
-        "url": "https://morfemalibreria.com.ar/resena-cien-anos.html"
+        "url": "https://morfemalibreria.com.ar/resenas/garcia_marquez_los_sims.html"
       }
     </script>
     <!-- Google tag (gtag.js) -->
@@ -130,6 +130,6 @@
         </a>
       </p>
     </div>
-    <script src="navbar.js"></script>
+    <script src="../navbar.js"></script>
   </body>
 </html>

--- a/src/resenas/index.html
+++ b/src/resenas/index.html
@@ -2,7 +2,7 @@
 <html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
-    <script src="load-gtm.js"></script>
+    <script src="../load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Reseñas - Morfema</title>
     <meta name="description" content="Lista de reseñas de libros en Morfema" />
@@ -16,10 +16,7 @@
       property="og:image"
       content="https://morfemalibreria.com.ar/logo400x400fondo.png"
     />
-    <meta
-      property="og:url"
-      content="https://morfemalibreria.com.ar/resenas.html"
-    />
+    <meta property="og:url" content="https://morfemalibreria.com.ar/resenas/" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -32,7 +29,7 @@
       name="twitter:image"
       content="https://morfemalibreria.com.ar/logo400x400fondo.png"
     />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="../styles.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
@@ -41,14 +38,14 @@
       href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="favicon.ico" type="image/x-icon" />
-    <link rel="canonical" href="/resenas.html" />
+    <link rel="icon" href="../favicon.ico" type="image/x-icon" />
+    <link rel="canonical" href="/resenas/" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Reseñas - Morfema",
-        "url": "https://morfemalibreria.com.ar/resenas.html"
+        "url": "https://morfemalibreria.com.ar/resenas/"
       }
     </script>
     <!-- Google tag (gtag.js) -->
@@ -71,7 +68,7 @@
       <h1 class="header">Reseñas</h1>
       <ul>
         <li>
-          <a href="resena-cien-anos.html"
+          <a href="garcia_marquez_los_sims.html"
             >Cien años de soledad; Gabriel García Márquez - ¿Qué tienen en común
             Los Sims y Cien años de soledad?</a
           >
@@ -90,6 +87,6 @@
         </a>
       </p>
     </div>
-    <script src="navbar.js"></script>
+    <script src="../navbar.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move review pages into `src/resenas/`
- update canonical URLs and navbar link
- support nested folders in build and sitemap scripts

## Testing
- `npm run format`
- `npx -y eslint@8 src/**/*.js test/**/*.js -f unix`
- `npm test`
- `npm run generate:sitemap`

------
https://chatgpt.com/codex/tasks/task_e_6882d2d3d6008322b3f68b70adbf8078