### PR TITLE
Rename reseñas section and fix navbar

### DIFF
--- a/src/navbar.html
+++ b/src/navbar.html
@@ -6,7 +6,7 @@
     <a href="catalogo.html">CATÁLOGO USADOS</a>
     <a href="vende.html">VENDÉ TUS LIBROS CON NOSOTROS</a>
     <a href="lee-gratis.html">LEÉ GRATIS</a>
-    <a href="resenas/">RESEÑAS</a>
+    <a href="nuestros-textos/">NUESTROS TEXTOS</a>
     <a href="talleres.html">TALLERES</a>
     <a href="quienes-somos.html">QUIÉNES SOMOS</a>
   </div>

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var container = document.getElementById('navbar');
     if (!container) return;
 
-    fetch('navbar.html')
+    fetch('/navbar.html')
         .then(function (res) { return res.text(); })
         .then(function (html) {
             container.innerHTML = html;

--- a/src/nuestros-textos/garcia_marquez_los_sims.html
+++ b/src/nuestros-textos/garcia_marquez_los_sims.html
@@ -15,7 +15,7 @@
     />
     <meta
       property="og:url"
-      content="https://morfemalibreria.com.ar/resenas/garcia_marquez_los_sims.html"
+      content="https://morfemalibreria.com.ar/nuestros-textos/garcia_marquez_los_sims.html"
     />
     <meta property="og:type" content="article" />
     <meta property="og:locale" content="es_AR" />
@@ -36,13 +36,13 @@
       rel="stylesheet"
     />
     <link rel="icon" href="../favicon.ico" type="image/x-icon" />
-    <link rel="canonical" href="/resenas/garcia_marquez_los_sims.html" />
+    <link rel="canonical" href="/nuestros-textos/garcia_marquez_los_sims.html" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "Review",
         "name": "Cien años de soledad - Reseña",
-        "url": "https://morfemalibreria.com.ar/resenas/garcia_marquez_los_sims.html"
+        "url": "https://morfemalibreria.com.ar/nuestros-textos/garcia_marquez_los_sims.html"
       }
     </script>
     <!-- Google tag (gtag.js) -->
@@ -60,7 +60,7 @@
     </script>
   </head>
   <body>
-    <div id="navbar" data-current="RESEÑAS"></div>
+    <div id="navbar" data-current="NUESTROS TEXTOS"></div>
     <div class="container review-content">
       <h1 class="header review-title">
         Cien años de soledad; Gabriel García Márquez - ¿Qué tienen en común Los

--- a/src/nuestros-textos/index.html
+++ b/src/nuestros-textos/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <script src="../load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Reseñas - Morfema</title>
+    <title>Nuestros textos - Morfema</title>
     <meta name="description" content="Lista de reseñas de libros en Morfema" />
     <meta name="robots" content="index, follow" />
-    <meta property="og:title" content="Reseñas - Morfema" />
+    <meta property="og:title" content="Nuestros textos - Morfema" />
     <meta
       property="og:description"
       content="Lista de reseñas de libros en Morfema"
@@ -16,11 +16,11 @@
       property="og:image"
       content="https://morfemalibreria.com.ar/logo400x400fondo.png"
     />
-    <meta property="og:url" content="https://morfemalibreria.com.ar/resenas/" />
+    <meta property="og:url" content="https://morfemalibreria.com.ar/nuestros-textos/" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Reseñas - Morfema" />
+    <meta name="twitter:title" content="Nuestros textos - Morfema" />
     <meta
       name="twitter:description"
       content="Lista de reseñas de libros en Morfema"
@@ -39,13 +39,13 @@
       rel="stylesheet"
     />
     <link rel="icon" href="../favicon.ico" type="image/x-icon" />
-    <link rel="canonical" href="/resenas/" />
+    <link rel="canonical" href="/nuestros-textos/" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "CollectionPage",
-        "name": "Reseñas - Morfema",
-        "url": "https://morfemalibreria.com.ar/resenas/"
+        "name": "Nuestros textos - Morfema",
+        "url": "https://morfemalibreria.com.ar/nuestros-textos/"
       }
     </script>
     <!-- Google tag (gtag.js) -->
@@ -63,9 +63,9 @@
     </script>
   </head>
   <body>
-    <div id="navbar" data-current="RESEÑAS"></div>
+    <div id="navbar" data-current="NUESTROS TEXTOS"></div>
     <div class="container">
-      <h1 class="header">Reseñas</h1>
+      <h1 class="header">Nuestros textos</h1>
       <ul>
         <li>
           <a href="garcia_marquez_los_sims.html"


### PR DESCRIPTION
## Summary
- rename `resenas` pages to `nuestros-textos`
- update navbar link text and URL
- fetch navbar using absolute path so subpages load it correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882d4c3c42c832298600e6bc69116e6