### PR TITLE
Add missing OG site_name tags

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -16,6 +16,7 @@
     <meta property="og:url" content="https://morfemalibreria.com.ar/404.html" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="404 - Página no encontrada" />
     <meta
@@ -31,7 +32,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/404.html" />
     <script type="application/ld+json">

--- a/src/catalogo.html
+++ b/src/catalogo.html
@@ -27,6 +27,7 @@
     <meta property="og:url" content="https://morfemalibreria.com.ar/" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Morfema - Librería" />
     <meta
@@ -45,7 +46,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,7 @@
     <meta property="og:url" content="https://morfemalibreria.com.ar/" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Morfema - Librería" />
     <meta
@@ -45,7 +46,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/src/lee-gratis.html
+++ b/src/lee-gratis.html
@@ -25,6 +25,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Leé gratis - Morfema" />
     <meta
@@ -40,7 +41,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/lee-gratis.html" />
     <script type="application/ld+json">

--- a/src/libro.html
+++ b/src/libro.html
@@ -30,6 +30,7 @@
     />
     <meta property="og:type" content="book" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Morfema - Libro" />
     <meta
@@ -47,7 +48,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <script type="application/ld+json" id="book-schema"></script>
     <script>

--- a/src/nuestros-textos/garcia_marquez_los_sims.html
+++ b/src/nuestros-textos/garcia_marquez_los_sims.html
@@ -19,6 +19,7 @@
     />
     <meta property="og:type" content="article" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Cien años de soledad - Reseña" />
     <meta name="twitter:description" content="Reseña de Cien años de soledad" />
@@ -36,7 +37,10 @@
       rel="stylesheet"
     />
     <link rel="icon" href="../favicon.ico" type="image/x-icon" />
-    <link rel="canonical" href="/nuestros-textos/garcia_marquez_los_sims.html" />
+    <link
+      rel="canonical"
+      href="/nuestros-textos/garcia_marquez_los_sims.html"
+    />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/src/nuestros-textos/index.html
+++ b/src/nuestros-textos/index.html
@@ -16,9 +16,13 @@
       property="og:image"
       content="https://morfemalibreria.com.ar/logo400x400fondo.png"
     />
-    <meta property="og:url" content="https://morfemalibreria.com.ar/nuestros-textos/" />
+    <meta
+      property="og:url"
+      content="https://morfemalibreria.com.ar/nuestros-textos/"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Nuestros textos - Morfema" />
     <meta

--- a/src/quienes-somos.ejs
+++ b/src/quienes-somos.ejs
@@ -14,6 +14,7 @@
 />
 <meta property="og:type" content="website" />
 <meta property="og:locale" content="es_AR" />
+<meta property="og:site_name" content="Morfema Librería" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Quiénes somos - Morfema" />
 <meta name="twitter:description" content="Conocé más sobre Morfema Librería" />

--- a/src/talleres.html
+++ b/src/talleres.html
@@ -25,6 +25,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Talleres - Morfema" />
     <meta
@@ -40,7 +41,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/talleres.html" />
     <script type="application/ld+json">

--- a/src/vende.html
+++ b/src/vende.html
@@ -25,6 +25,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Vendé tus libros - Morfema" />
     <meta
@@ -40,7 +41,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/vende.html" />
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- add `og:site_name` metadata across all HTML pages for social sharing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882d72218608322a77c11338322237a