### PR TITLE
Fix section links and rename texts area

### DIFF
--- a/src/navbar.html
+++ b/src/navbar.html
@@ -6,7 +6,7 @@
     <a href="catalogo.html">CATÁLOGO USADOS</a>
     <a href="vende.html">VENDÉ TUS LIBROS CON NOSOTROS</a>
     <a href="lee-gratis.html">LEÉ GRATIS</a>
-    <a href="nuestros-textos/">NUESTROS TEXTOS</a>
+    <a href="textos-de-morfema/">TEXTOS DE MORFEMA</a>
     <a href="talleres.html">TALLERES</a>
     <a href="quienes-somos.html">QUIÉNES SOMOS</a>
   </div>

--- a/src/textos-de-morfema/garcia_marquez_los_sims.html
+++ b/src/textos-de-morfema/garcia_marquez_los_sims.html
@@ -15,7 +15,7 @@
     />
     <meta
       property="og:url"
-      content="https://morfemalibreria.com.ar/nuestros-textos/garcia_marquez_los_sims.html"
+      content="https://morfemalibreria.com.ar/textos-de-morfema/garcia_marquez_los_sims.html"
     />
     <meta property="og:type" content="article" />
     <meta property="og:locale" content="es_AR" />
@@ -39,14 +39,14 @@
     <link rel="icon" href="../favicon.ico" type="image/x-icon" />
     <link
       rel="canonical"
-      href="/nuestros-textos/garcia_marquez_los_sims.html"
+      href="/textos-de-morfema/garcia_marquez_los_sims.html"
     />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "Review",
         "name": "Cien años de soledad - Reseña",
-        "url": "https://morfemalibreria.com.ar/nuestros-textos/garcia_marquez_los_sims.html"
+        "url": "https://morfemalibreria.com.ar/textos-de-morfema/garcia_marquez_los_sims.html"
       }
     </script>
     <!-- Google tag (gtag.js) -->
@@ -64,7 +64,7 @@
     </script>
   </head>
   <body>
-    <div id="navbar" data-current="NUESTROS TEXTOS"></div>
+    <div id="navbar" data-current="TEXTOS DE MORFEMA"></div>
     <div class="container review-content">
       <h1 class="header review-title">
         Cien años de soledad; Gabriel García Márquez - ¿Qué tienen en común Los

--- a/src/textos-de-morfema/index.html
+++ b/src/textos-de-morfema/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <script src="../load-gtm.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Nuestros textos - Morfema</title>
+    <title>Textos de Morfema</title>
     <meta name="description" content="Lista de reseñas de libros en Morfema" />
     <meta name="robots" content="index, follow" />
-    <meta property="og:title" content="Nuestros textos - Morfema" />
+    <meta property="og:title" content="Textos de Morfema" />
     <meta
       property="og:description"
       content="Lista de reseñas de libros en Morfema"
@@ -18,13 +18,13 @@
     />
     <meta
       property="og:url"
-      content="https://morfemalibreria.com.ar/nuestros-textos/"
+      content="https://morfemalibreria.com.ar/textos-de-morfema/"
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
     <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Nuestros textos - Morfema" />
+    <meta name="twitter:title" content="Textos de Morfema" />
     <meta
       name="twitter:description"
       content="Lista de reseñas de libros en Morfema"
@@ -43,13 +43,13 @@
       rel="stylesheet"
     />
     <link rel="icon" href="../favicon.ico" type="image/x-icon" />
-    <link rel="canonical" href="/nuestros-textos/" />
+    <link rel="canonical" href="/textos-de-morfema/" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "CollectionPage",
-        "name": "Nuestros textos - Morfema",
-        "url": "https://morfemalibreria.com.ar/nuestros-textos/"
+        "name": "Textos de Morfema",
+        "url": "https://morfemalibreria.com.ar/textos-de-morfema/"
       }
     </script>
     <!-- Google tag (gtag.js) -->
@@ -67,9 +67,9 @@
     </script>
   </head>
   <body>
-    <div id="navbar" data-current="NUESTROS TEXTOS"></div>
+    <div id="navbar" data-current="TEXTOS DE MORFEMA"></div>
     <div class="container">
-      <h1 class="header">Nuestros textos</h1>
+      <h1 class="header">Textos de Morfema</h1>
       <ul>
         <li>
           <a href="garcia_marquez_los_sims.html"


### PR DESCRIPTION
## Summary
- rename `nuestros-textos` section to `textos-de-morfema`
- update navigation link
- fix canonical URLs and metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882d9ba38e08322a13b5badd11dd1ee