### PR TITLE
Fix base tag output in head template

### DIFF
--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -34,6 +34,10 @@ const urls = pages.map((file) => {
   if (file === 'index.html') {
     return `${baseUrl}/`;
   }
+  if (file.endsWith('/index.html')) {
+    const dir = file.slice(0, -'index.html'.length);
+    return `${baseUrl}/${dir}`;
+  }
   return `${baseUrl}/${file}`;
 });
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,6 +7,6 @@
   <url><loc>https://morfemalibreria.com.ar/quienes-somos.html</loc></url>
   <url><loc>https://morfemalibreria.com.ar/talleres.html</loc></url>
   <url><loc>https://morfemalibreria.com.ar/textos-de-morfema/garcia_marquez_los_sims.html</loc></url>
-  <url><loc>https://morfemalibreria.com.ar/textos-de-morfema/index.html</loc></url>
+  <url><loc>https://morfemalibreria.com.ar/textos-de-morfema/</loc></url>
   <url><loc>https://morfemalibreria.com.ar/vende.html</loc></url>
 </urlset>

--- a/src/lee-gratis.html
+++ b/src/lee-gratis.html
@@ -25,6 +25,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Leé gratis - Morfema" />
     <meta
@@ -40,7 +41,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/lee-gratis.html" />
     <script type="application/ld+json">

--- a/src/libro.html
+++ b/src/libro.html
@@ -30,6 +30,7 @@
     />
     <meta property="og:type" content="book" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Morfema - Libro" />
     <meta
@@ -47,7 +48,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <script type="application/ld+json" id="book-schema"></script>
     <script>

--- a/src/quienes-somos.ejs
+++ b/src/quienes-somos.ejs
@@ -12,6 +12,7 @@
 <meta property="og:url" content="https://morfemalibreria.com.ar/quienes-somos.html" />
 <meta property="og:type" content="website" />
 <meta property="og:locale" content="es_AR" />
+<meta property="og:site_name" content="Morfema Librería" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Quiénes somos - Morfema" />
 <meta name="twitter:description" content="Conocé más sobre Morfema Librería" />

--- a/src/talleres.html
+++ b/src/talleres.html
@@ -25,6 +25,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Talleres - Morfema" />
     <meta
@@ -40,7 +41,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/talleres.html" />
     <script type="application/ld+json">

--- a/src/templates/head.ejs
+++ b/src/templates/head.ejs
@@ -1,5 +1,6 @@
 <% const basePath = typeof base !== 'undefined' ? base : '' %>
 <meta charset="UTF-8" />
+<% if (basePath) { %><base href="<%= basePath %>" /><% } %>
 <script src="<%= basePath %>load-gtm.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title><%= title %></title>

--- a/src/vende.html
+++ b/src/vende.html
@@ -25,6 +25,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="Morfema Librería" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Vendé tus libros - Morfema" />
     <meta
@@ -40,7 +41,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     />
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato&family=Merriweather&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="/vende.html" />
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- only emit `<base>` tag when a non-empty `base` path is provided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883a79169fc8322b1cf5448f48dacc6