### PR TITLE
Enhance textos layout and reading time

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -64,6 +64,9 @@ body {
     font-size: 28px;
     font-weight: bold;
 }
+.header-left {
+    text-align: left;
+}
 .logo-container {
     display: flex;
     justify-content: center;
@@ -81,6 +84,11 @@ body {
     text-align: center;
     font-size: 20px;
     margin-bottom: 20px;
+}
+.section-title {
+    text-align: left;
+    font-size: 24px;
+    margin: 20px 0 10px;
 }
 .search-box {
     display: flex;
@@ -394,4 +402,10 @@ body {
 .review-title {
     font-family: 'Montserrat', sans-serif;
     font-weight: 900;
+}
+
+.reading-time {
+    font-family: Arial, sans-serif;
+    color: #607d8b;
+    margin-bottom: 1em;
 }

--- a/src/textos-de-morfema/garcia_marquez_los_sims.html
+++ b/src/textos-de-morfema/garcia_marquez_los_sims.html
@@ -71,6 +71,7 @@
         Cien años de soledad; Gabriel García Márquez - ¿Qué tienen en común Los
         Sims y Cien años de soledad?
       </h1>
+      <p class="reading-time">Tiempo estimado de lectura: 3 minutos</p>
       <p>
         Llevaba leído algo así como un cuarto del libro cuando lo definí, un
         poco en chiste, como una historia sacada de una partida ambiciosa del

--- a/src/textos-de-morfema/index.html
+++ b/src/textos-de-morfema/index.html
@@ -70,7 +70,8 @@
   <body>
     <div id="navbar" data-current="TEXTOS DE MORFEMA"></div>
     <div class="container">
-      <h1 class="header">Textos de Morfema</h1>
+      <h1 class="header header-left">Textos de Morfema</h1>
+      <h2 class="section-title">Reseñas para Instagram</h2>
       <ul>
         <li>
           <a href="garcia_marquez_los_sims.html"


### PR DESCRIPTION
## Summary
- group the textos under a new section title
- left-align the header for the textos index
- show estimated reading time in article
- style section titles and reading time text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688409e2dd8c8322a4abbda98eb5fcb4