### PR TITLE
Add Firestore support and comments module

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,5 +6,9 @@
       "**/.*",
       "**/node_modules/**"
     ]
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,16 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /reviews/{slug}/comments/{commentId} {
+      allow read: if true;
+      allow create: if
+        request.resource.data.keys().hasOnly(['name', 'message', 'createdAt', 'recaptchaToken']) &&
+        request.resource.data.name is string &&
+        request.resource.data.message is string &&
+        request.resource.data.name.size() > 0 && request.resource.data.name.size() <= 100 &&
+        request.resource.data.message.size() > 0 && request.resource.data.message.size() <= 1000 &&
+        request.time == request.resource.data.createdAt &&
+        (!('recaptchaToken' in request.resource.data) || request.resource.data.recaptchaToken is string);
+    }
+  }
+}

--- a/src/comments.js
+++ b/src/comments.js
@@ -1,0 +1,40 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js';
+import {
+  getFirestore,
+  collection,
+  query,
+  orderBy,
+  getDocs,
+  addDoc,
+  serverTimestamp
+} from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+import config from './firebase-config.js';
+
+let app;
+let db;
+
+export function init() {
+  if (!app) {
+    app = initializeApp(config);
+    db = getFirestore(app);
+  }
+  return db;
+}
+
+export async function loadComments(slug) {
+  const database = db || init();
+  const q = query(collection(database, 'reviews', slug, 'comments'), orderBy('createdAt'));
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => d.data());
+}
+
+export async function addComment(slug, name, message, recaptchaToken) {
+  const database = db || init();
+  const data = {
+    name: String(name),
+    message: String(message),
+    createdAt: serverTimestamp()
+  };
+  if (recaptchaToken) data.recaptchaToken = recaptchaToken;
+  return addDoc(collection(database, 'reviews', slug, 'comments'), data);
+}

--- a/src/firebase-config.js
+++ b/src/firebase-config.js
@@ -1,0 +1,7 @@
+// Firebase configuration for morfemalibreria-b8c79
+// Replace the values below with your project's configuration
+export default {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'morfemalibreria-b8c79.firebaseapp.com',
+  projectId: 'morfemalibreria-b8c79'
+};


### PR DESCRIPTION
## Summary
- initialize Firestore settings
- add spam-protection rules
- create Firebase config placeholder
- implement `comments.js` helper for loading and submitting comments

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68892023cb548322947cb92d6dca4c64