### PR TITLE
Refactor comments to ES module

### DIFF
--- a/build.js
+++ b/build.js
@@ -28,13 +28,17 @@ function processDir(srcPath, outPath) {
     } else if (entry.name.endsWith('.html')) {
       fs.copyFileSync(srcFile, outFile);
     } else if (entry.name.endsWith('.js')) {
-      esbuild.buildSync({
-        entryPoints: [srcFile],
-        outfile: outFile,
-        bundle: false,
-        minify: true,
-        format: 'iife',
-      });
+      if (entry.name === 'comments-esm.js') {
+        fs.copyFileSync(srcFile, outFile);
+      } else {
+        esbuild.buildSync({
+          entryPoints: [srcFile],
+          outfile: outFile,
+          bundle: false,
+          minify: true,
+          format: 'iife',
+        });
+      }
     } else if (entry.name.endsWith('.css')) {
       const css = fs.readFileSync(srcFile, 'utf8');
       fs.writeFileSync(outFile, css);

--- a/src/comments-esm.js
+++ b/src/comments-esm.js
@@ -13,7 +13,7 @@ import config from './firebase-config.js';
 let app;
 let db;
 
-export function init() {
+function init() {
   if (!app) {
     app = initializeApp(config);
     db = getFirestore(app);
@@ -21,14 +21,14 @@ export function init() {
   return db;
 }
 
-export async function loadComments(slug) {
+async function loadComments(slug) {
   const database = db || init();
   const q = query(collection(database, 'reviews', slug, 'comments'), orderBy('createdAt'));
   const snapshot = await getDocs(q);
   return snapshot.docs.map((d) => d.data());
 }
 
-export async function addComment(slug, name, message, recaptchaToken) {
+async function addComment(slug, name, message, recaptchaToken) {
   const database = db || init();
   const data = {
     name: String(name),
@@ -39,7 +39,7 @@ export async function addComment(slug, name, message, recaptchaToken) {
   return addDoc(collection(database, 'reviews', slug, 'comments'), data);
 }
 
-export async function initComments(slug) {
+async function initComments(slug) {
   const form = document.getElementById("comment-form");
   const list = document.getElementById("comment-list");
 
@@ -75,3 +75,5 @@ export async function initComments(slug) {
     console.error("Error al cargar comentarios:", err);
   }
 }
+
+export { initComments };

--- a/test/test.js
+++ b/test/test.js
@@ -10,8 +10,8 @@ try {
   const validate = ajv.compile(schema);
 
   assert.ok(
-    fs.existsSync(path.join('dist', 'comments.js')),
-    'dist/comments.js should exist after build'
+    fs.existsSync(path.join('dist', 'comments-esm.js')),
+    'dist/comments-esm.js should exist after build'
   );
 
   const content = fs.readFileSync('dist/books.json', 'utf8');


### PR DESCRIPTION
## Summary
- rewrite comments-esm.js to expose `initComments` as an ES module
- avoid bundling/minifying comments-esm.js during build
- adjust tests for new output file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68896273b4148322bd98e135ed535200