### PR TITLE
Add moderated comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,7 @@ El archivo `firebase.json` configura Firebase Hosting para publicar el contenido
 {
   "hosting": {
     "public": "dist",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   }
 }
 ```
@@ -90,6 +86,13 @@ Luego selecciona tu proyecto y confirma la actualización de `.firebaserc`.
 
 Las reseñas permiten comentarios guardados en Firebase. Debes colocar las
 claves de tu proyecto en `src/firebase-config.js`.
+
+Los comentarios nuevos se guardan con el estado `approved: false` y no son
+visibles públicamente hasta que un administrador los aprueba desde
+`/admin.html?slug=ID_DE_RESEÑA`.
+
+Para aprobarlos debes iniciar sesión con un usuario que tenga el claim
+personalizado `admin: true` en Firebase Authentication.
 
 ## Reglas de seguridad de Firestore
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,12 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /reviews/{slug}/comments/{commentId} {
-      allow read: if true;
+      function isAdmin() {
+        return request.auth != null && request.auth.token.admin == true;
+      }
+
+      allow read: if resource.data.approved == true || isAdmin();
+
       allow create: if
         request.resource.data.keys().hasOnly(['name', 'message', 'createdAt', 'recaptchaToken']) &&
         request.resource.data.name is string &&
@@ -11,6 +16,8 @@ service cloud.firestore {
         request.resource.data.message.size() > 0 && request.resource.data.message.size() <= 1000 &&
         request.time == request.resource.data.createdAt &&
         (!('recaptchaToken' in request.resource.data) || request.resource.data.recaptchaToken is string);
+
+      allow update, delete: if isAdmin();
     }
   }
 }

--- a/src/admin.html
+++ b/src/admin.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="es-AR">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="/load-gtm.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Moderación de comentarios</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div id="navbar" data-current=""></div>
+    <h1>Comentarios pendientes</h1>
+    <ul id="pending-list"></ul>
+    <script type="module" src="/admin.js"></script>
+    <script src="/navbar.js"></script>
+  </body>
+</html>

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,0 +1,43 @@
+import {
+  init,
+  loadPendingComments,
+  approveComment,
+  deleteComment,
+} from './comments-esm.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('slug');
+  if (!slug) {
+    document.getElementById('pending-list').textContent =
+      'Falta el parametro slug';
+    return;
+  }
+
+  await init();
+  const list = document.getElementById('pending-list');
+  try {
+    const comments = await loadPendingComments(slug);
+    for (const { id, name, message } of comments) {
+      const li = document.createElement('li');
+      li.textContent = `${name}: ${message} `;
+      const approveBtn = document.createElement('button');
+      approveBtn.textContent = 'Aprobar';
+      approveBtn.addEventListener('click', async () => {
+        await approveComment(slug, id);
+        li.remove();
+      });
+      const deleteBtn = document.createElement('button');
+      deleteBtn.textContent = 'Eliminar';
+      deleteBtn.addEventListener('click', async () => {
+        await deleteComment(slug, id);
+        li.remove();
+      });
+      li.appendChild(approveBtn);
+      li.appendChild(deleteBtn);
+      list.appendChild(li);
+    }
+  } catch (err) {
+    console.error('Error cargando comentarios pendientes', err);
+  }
+});


### PR DESCRIPTION
## Summary
- support pending comments with `approved` field in Firebase
- new admin page to approve or delete comments
- update security rules to allow admin moderation
- document moderation workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a05813514832291b0f26b0d485e43