### PR TITLE
Implement HTML wizard form

### DIFF
--- a/src/vende.html
+++ b/src/vende.html
@@ -45,8 +45,134 @@
           </div>
         </div>
       </section>
-      <!-- Form placeholder -->
-      <section class="form-wizard"></section>
+      <!-- Form wizard for selling books -->
+      <section class="form-wizard" id="form">
+        <form id="book-sell-form">
+          <!-- Progress indicator -->
+          <ol class="form-progress">
+            <li class="progress-step current" data-step="1">1</li>
+            <li class="progress-step" data-step="2">2</li>
+            <li class="progress-step" data-step="3">3</li>
+            <li class="progress-step" data-step="4">4</li>
+          </ol>
+
+          <!-- Step 1 – Seller Information -->
+          <div class="form-step" data-step="1">
+            <h2>Datos del vendedor</h2>
+            <label for="seller-name">Nombre</label>
+            <input type="text" id="seller-name" name="sellerName" required />
+
+            <label for="seller-email">Email</label>
+            <input type="email" id="seller-email" name="sellerEmail" required />
+
+            <label for="seller-phone">Teléfono</label>
+            <input type="tel" id="seller-phone" name="sellerPhone" required />
+
+            <div class="form-navigation">
+              <button type="button" class="next-button">Siguiente</button>
+            </div>
+          </div>
+
+          <!-- Step 2 – Book Information -->
+          <div class="form-step" data-step="2" hidden>
+            <h2>Datos del libro</h2>
+            <label for="book-title">Título</label>
+            <input type="text" id="book-title" name="bookTitle" required />
+
+            <label for="book-author">Autor</label>
+            <input type="text" id="book-author" name="bookAuthor" required />
+
+            <label for="book-publisher">Editorial</label>
+            <input
+              type="text"
+              id="book-publisher"
+              name="bookPublisher"
+              required
+            />
+
+            <label for="book-condition">Estado</label>
+            <select id="book-condition" name="bookCondition" required>
+              <option value="">Seleccioná</option>
+              <option>Nuevo</option>
+              <option>Excelente</option>
+              <option>Bueno</option>
+              <option>Usado con detalles</option>
+            </select>
+
+            <label for="book-price">Precio sugerido</label>
+            <input type="number" id="book-price" name="bookPrice" />
+
+            <label for="book-photo">Foto del libro</label>
+            <input
+              type="file"
+              id="book-photo"
+              name="bookPhoto"
+              accept="image/*"
+            />
+            <div class="photo-preview"><!-- preview goes here --></div>
+
+            <div class="form-navigation">
+              <button type="button" class="prev-button">Anterior</button>
+              <button type="button" class="next-button">Siguiente</button>
+            </div>
+          </div>
+
+          <!-- Step 3 – Delivery & Location -->
+          <div class="form-step" data-step="3" hidden>
+            <h2>Entrega y ubicación</h2>
+            <label for="zone">Zona</label>
+            <input type="text" id="zone" name="zone" required />
+
+            <fieldset>
+              <legend>Entrega</legend>
+              <label for="bring">
+                <input
+                  type="radio"
+                  id="bring"
+                  name="delivery"
+                  value="bring"
+                  checked
+                />
+                Lo acerco
+              </label>
+              <label for="pickup">
+                <input
+                  type="radio"
+                  id="pickup"
+                  name="delivery"
+                  value="pickup"
+                />
+                Quiero que lo retiren
+              </label>
+            </fieldset>
+
+            <label for="availability">Disponibilidad</label>
+            <textarea id="availability" name="availability"></textarea>
+
+            <div class="form-navigation">
+              <button type="button" class="prev-button">Anterior</button>
+              <button type="button" class="next-button">Siguiente</button>
+            </div>
+          </div>
+
+          <!-- Step 4 – Confirmation -->
+          <div class="form-step" data-step="4" hidden>
+            <h2>Confirmación</h2>
+            <div class="review-data">
+              <!-- datos ingresados -->
+            </div>
+            <label for="terms" class="terms">
+              <input type="checkbox" id="terms" required /> Acepto términos y
+              condiciones
+            </label>
+
+            <div class="form-navigation">
+              <button type="button" class="prev-button">Anterior</button>
+              <button type="submit" class="submit-button">Enviar</button>
+            </div>
+          </div>
+        </form>
+      </section>
       <!-- Testimonials section -->
       <section class="testimonials"></section>
       <!-- FAQs section -->

--- a/src/vende.html
+++ b/src/vende.html
@@ -49,11 +49,18 @@
       <section class="form-wizard" id="form">
         <form id="book-sell-form">
           <!-- Progress indicator -->
-          <ol class="form-progress">
-            <li class="progress-step current" data-step="1">1</li>
-            <li class="progress-step" data-step="2">2</li>
-            <li class="progress-step" data-step="3">3</li>
-            <li class="progress-step" data-step="4">4</li>
+          <ol class="form-progress" aria-label="Progreso del formulario">
+            <li
+              class="progress-step current"
+              data-step="1"
+              aria-label="Paso 1"
+              aria-current="step"
+            >
+              1
+            </li>
+            <li class="progress-step" data-step="2" aria-label="Paso 2">2</li>
+            <li class="progress-step" data-step="3" aria-label="Paso 3">3</li>
+            <li class="progress-step" data-step="4" aria-label="Paso 4">4</li>
           </ol>
 
           <!-- Step 1 – Seller Information -->


### PR DESCRIPTION
## Summary
- implement a multi-step wizard form on the /vende page
- add placeholders for seller information, book information, delivery options and confirmation

## Testing
- `npm run format` (only targeted file)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a10e83fbc8322b7ba96679b795163