### PR TITLE
Add multistep form styles for /vende

### DIFF
--- a/public/styles/vende.css
+++ b/public/styles/vende.css
@@ -107,3 +107,98 @@
     max-width: 300px;
   }
 }
+
+/* Multistep form */
+.form-wizard {
+  max-width: 600px;
+  margin: 40px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.progress-indicator {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.progress-step {
+  flex: 1;
+  height: 4px;
+  background: #e0e0e0;
+  margin: 0 4px;
+  border-radius: 2px;
+  position: relative;
+}
+
+.progress-step.active,
+.progress-step.completed {
+  background: #112a4a;
+}
+
+.form-step {
+  display: none;
+  flex-direction: column;
+  gap: 15px;
+  animation: fade 0.3s ease;
+}
+
+.form-step.current-step {
+  display: flex;
+}
+
+.field-group label {
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+
+.field-group input,
+.field-group select,
+.field-group textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-sizing: border-box;
+  font-size: 1rem;
+}
+
+.buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+
+.prev-button,
+.next-button {
+  background: #112a4a;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.prev-button:hover,
+.next-button:hover {
+  background: #0d1f3d;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (min-width: 768px) {
+  .form-step.two-column {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+}

--- a/src/form.js
+++ b/src/form.js
@@ -1,1 +1,37 @@
-// Placeholder for sell books form logic
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.getElementById('sell-form');
+  if (!form) return;
+
+  const steps = form.querySelectorAll('.form-step');
+  const progress = document.querySelectorAll('.progress-step');
+  let current = 0;
+
+  function showStep(index) {
+    steps.forEach(function (step, i) {
+      step.classList.toggle('current-step', i === index);
+    });
+    progress.forEach(function (p, i) {
+      p.classList.toggle('active', i === index);
+      p.classList.toggle('completed', i < index);
+    });
+  }
+
+  form.addEventListener('click', function (e) {
+    if (e.target.closest('.next-button')) {
+      e.preventDefault();
+      if (current < steps.length - 1) {
+        current += 1;
+        showStep(current);
+      }
+    }
+    if (e.target.closest('.prev-button')) {
+      e.preventDefault();
+      if (current > 0) {
+        current -= 1;
+        showStep(current);
+      }
+    }
+  });
+
+  showStep(current);
+});

--- a/src/vende.html
+++ b/src/vende.html
@@ -45,8 +45,72 @@
           </div>
         </div>
       </section>
-      <!-- Form placeholder -->
-      <section class="form-wizard"></section>
+      <!-- Multistep form -->
+      <section class="form-wizard" id="form">
+        <div class="progress-indicator">
+          <div class="progress-step"></div>
+          <div class="progress-step"></div>
+          <div class="progress-step"></div>
+          <div class="progress-step"></div>
+        </div>
+        <form id="sell-form">
+          <div class="form-step current-step">
+            <div class="field-group">
+              <label for="name">Nombre</label>
+              <input type="text" id="name" name="name" required />
+            </div>
+            <div class="field-group">
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" required />
+            </div>
+            <div class="buttons">
+              <button type="button" class="next-button">Siguiente</button>
+            </div>
+          </div>
+          <div class="form-step">
+            <div class="field-group">
+              <label for="title">Título del libro</label>
+              <input type="text" id="title" name="title" required />
+            </div>
+            <div class="field-group">
+              <label for="author">Autor</label>
+              <input type="text" id="author" name="author" required />
+            </div>
+            <div class="buttons">
+              <button type="button" class="prev-button">Anterior</button>
+              <button type="button" class="next-button">Siguiente</button>
+            </div>
+          </div>
+          <div class="form-step">
+            <div class="field-group">
+              <label for="condition">Estado del libro</label>
+              <select id="condition" name="condition" required>
+                <option value="" disabled selected>Seleccioná</option>
+                <option value="nuevo">Nuevo</option>
+                <option value="usado">Usado</option>
+              </select>
+            </div>
+            <div class="field-group">
+              <label for="price">Precio sugerido</label>
+              <input type="number" id="price" name="price" required />
+            </div>
+            <div class="buttons">
+              <button type="button" class="prev-button">Anterior</button>
+              <button type="button" class="next-button">Siguiente</button>
+            </div>
+          </div>
+          <div class="form-step">
+            <div class="field-group">
+              <label for="notes">Comentarios adicionales</label>
+              <textarea id="notes" name="notes" rows="4"></textarea>
+            </div>
+            <div class="buttons">
+              <button type="button" class="prev-button">Anterior</button>
+              <button type="submit" class="next-button">Enviar</button>
+            </div>
+          </div>
+        </form>
+      </section>
       <!-- Testimonials section -->
       <section class="testimonials"></section>
       <!-- FAQs section -->


### PR DESCRIPTION
## Summary
- implement wizard form markup on `/vende` page
- add interactive script to navigate form steps
- style progress indicator and buttons in `vende.css`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a1290fb8883229ca70a1bbb24c0b0