### PR TITLE
Fix hero alignment on sell page

### DIFF
--- a/public/styles/vende.css
+++ b/public/styles/vende.css
@@ -1,5 +1,11 @@
 /* Styles for vendé tus libros landing page */
 
+/* Container with wider max-width for landing page */
+.wide-container {
+  max-width: 1200px;
+  margin: 20px auto;
+}
+
 .hidden {
   display: none;
 }
@@ -15,7 +21,7 @@
   align-items: center;
   justify-content: center;
   gap: 40px;
-  max-width: 1200px;
+  max-width: 100%;
   margin: 0 auto;
   flex-wrap: wrap;
 }
@@ -82,7 +88,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 20px;
-  max-width: 1200px;
+  max-width: 100%;
   margin: 0 auto;
 }
 

--- a/src/vende.html
+++ b/src/vende.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <div id="navbar" data-current="VENDÉ TUS LIBROS CON NOSOTROS"></div>
-    <div class="container">
+    <div class="container wide-container">
       <main>
         <!-- Hero section -->
         <section class="hero">


### PR DESCRIPTION
## Summary
- widen sell page container to align hero and how-it-works sections
- keep inner elements within container width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a26fd64ac8322b253b164af01c273