### PR TITLE
Revamp sell form

### DIFF
--- a/public/styles/vende.css
+++ b/public/styles/vende.css
@@ -198,9 +198,35 @@
   cursor: pointer;
 }
 
+.submit-button {
+  background: #112a4a;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
 .prev-button:hover,
 .next-button:hover {
   background: #0d1f3d;
+}
+
+.submit-button:hover {
+  background: #0d1f3d;
+}
+
+.book-fields {
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  padding: 15px;
+  margin-bottom: 15px;
+}
+
+.success-message {
+  text-align: center;
+  font-size: 1.2rem;
+  padding: 20px 0;
 }
 
 @keyframes fade {

--- a/src/form.js
+++ b/src/form.js
@@ -1,17 +1,193 @@
-document.addEventListener('DOMContentLoaded', function () { const formSection =
-document.getElementById('form'); const form =
-document.getElementById('sell-form'); if (formSection) {
-formSection.classList.add('hidden'); } if (!form) return; const startButton =
-document.querySelector('[data-scroll-to="form"]'); if (startButton &&
-formSection) { startButton.addEventListener('click', function () {
-formSection.classList.remove('hidden'); formSection.scrollIntoView({ behavior:
-'smooth' }); }); } const steps = form.querySelectorAll('.form-step'); const
-progress = document.querySelectorAll('.progress-step'); let current = 0;
-function showStep(index) { steps.forEach(function (step, i) {
-step.classList.toggle('current-step', i === index); });
-progress.forEach(function (p, i) { p.classList.toggle('active', i === index);
-p.classList.toggle('completed', i < index); }); } form.addEventListener('click',
-function (e) { if (e.target.closest('.next-button')) { e.preventDefault(); if
-(current < steps.length - 1) { current += 1; showStep(current); } } if
-(e.target.closest('.prev-button')) { e.preventDefault(); if (current > 0) {
-current -= 1; showStep(current); } } }); showStep(current); });
+// Multistep form logic for vende page
+document.addEventListener('DOMContentLoaded', function () {
+  const formSection = document.getElementById('form');
+  const form = document.getElementById('sell-form');
+  if (formSection) {
+    formSection.classList.add('hidden');
+  }
+
+  const startButton = document.querySelector('[data-scroll-to="form"]');
+  if (startButton && formSection) {
+    startButton.addEventListener('click', function () {
+      formSection.classList.remove('hidden');
+      formSection.scrollIntoView({ behavior: 'smooth' });
+    });
+  }
+
+  if (!form) return;
+
+  const steps = form.querySelectorAll('.form-step');
+  const progress = document.querySelectorAll('.progress-step');
+  let current = 0;
+
+  function showStep(index) {
+    steps.forEach(function (step, i) {
+      step.classList.toggle('current-step', i === index);
+    });
+    progress.forEach(function (p, i) {
+      p.classList.toggle('active', i === index);
+      p.classList.toggle('completed', i < index);
+    });
+  }
+
+  function validateStep(idx) {
+    const step = steps[idx];
+    const fields = step.querySelectorAll(
+      'input[required], select[required], textarea[required]',
+    );
+    for (const field of fields) {
+      if (!field.checkValidity()) {
+        field.reportValidity();
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function createBookBlocks(count) {
+    const container = document.getElementById('book-steps');
+    if (!container) return;
+    container.innerHTML = '';
+    for (let i = 1; i <= count; i++) {
+      const div = document.createElement('div');
+      div.className = 'book-fields';
+      div.dataset.book = String(i);
+      div.innerHTML =
+        '<h3>Libro ' +
+        i +
+        '</h3>' +
+        '<div class="field-group">' +
+        '<label for="title-' +
+        i +
+        '">Título</label>' +
+        '<input type="text" id="title-' +
+        i +
+        '" name="title-' +
+        i +
+        '" required />' +
+        '</div>' +
+        '<div class="field-group">' +
+        '<label for="price-' +
+        i +
+        '">Precio</label>' +
+        '<input type="number" id="price-' +
+        i +
+        '" name="price-' +
+        i +
+        '" required />' +
+        '</div>' +
+        '<div class="field-group">' +
+        '<label for="state-' +
+        i +
+        '">Estado</label>' +
+        '<select id="state-' +
+        i +
+        '" name="state-' +
+        i +
+        '" required>' +
+        '<option value="" disabled selected hidden>Seleccioná</option>' +
+        '<option>Como nuevo</option>' +
+        '<option>Muy bueno</option>' +
+        '<option>Detalles</option>' +
+        '</select>' +
+        '</div>' +
+        '<div class="field-group">' +
+        '<label for="notes-' +
+        i +
+        '">Observaciones</label>' +
+        '<textarea id="notes-' +
+        i +
+        '" name="notes-' +
+        i +
+        '" placeholder="Acá nos podés comentar si el libro está en otro idioma, si es una edición especial, si tiene detalles, y cualquier otro comentario que creas conveniente."></textarea>' +
+        '</div>' +
+        '<div class="field-group">' +
+        '<label for="photo-' +
+        i +
+        '">Foto</label>' +
+        '<input type="file" id="photo-' +
+        i +
+        '" name="photo-' +
+        i +
+        '" accept="image/*" required />' +
+        '<small>Necesitamos una foto principal de la portada, lo más cerca posible.</small>' +
+        '</div>';
+      container.appendChild(div);
+    }
+  }
+
+  function renderSummary() {
+    const summary = document.getElementById('summary');
+    if (!summary) return;
+    summary.innerHTML =
+      '<p><strong>Nombre:</strong> ' +
+      form.name.value +
+      '</p>' +
+      '<p><strong>Email:</strong> ' +
+      form.email.value +
+      ' <small>Este dato es importante porque nos vamos a contactar con vos por ahí.</small></p>' +
+      '<p><strong>Ciudad:</strong> ' +
+      form.city.value +
+      '</p>' +
+      '<p><strong>Cantidad de libros:</strong> ' +
+      form['book-count'].value +
+      '</p>';
+    const count = parseInt(form['book-count'].value, 10) || 0;
+    for (let i = 1; i <= count; i++) {
+      const details = document.createElement('details');
+      const title = form['title-' + i].value;
+      const price = form['price-' + i].value;
+      const state = form['state-' + i].value;
+      const notes = form['notes-' + i].value;
+      details.innerHTML =
+        '<summary>Libro ' +
+        i +
+        ': ' +
+        title +
+        '</summary>' +
+        '<p><strong>Precio:</strong> ' +
+        price +
+        '</p>' +
+        '<p><strong>Estado:</strong> ' +
+        state +
+        '</p>' +
+        (notes ? '<p><strong>Observaciones:</strong> ' + notes + '</p>' : '');
+      summary.appendChild(details);
+    }
+  }
+
+  form.addEventListener('click', function (e) {
+    if (e.target.closest('.next-button')) {
+      e.preventDefault();
+      if (!validateStep(current)) return;
+      if (current === 1) {
+        const count = parseInt(form['book-count'].value, 10);
+        if (Number.isNaN(count) || count < 1) return;
+        createBookBlocks(count);
+      }
+      if (current === 2) {
+        renderSummary();
+      }
+      if (current < steps.length - 1) {
+        current += 1;
+        showStep(current);
+      }
+    }
+    if (e.target.closest('.prev-button')) {
+      e.preventDefault();
+      if (current > 0) {
+        current -= 1;
+        showStep(current);
+      }
+    }
+  });
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    if (!validateStep(current)) return;
+    form.innerHTML =
+      '<p class="success-message">\u00a1Gracias! Nos vamos a estar comunicando con vos por mail.</p>';
+  });
+
+  showStep(current);
+});

--- a/src/vende.html
+++ b/src/vende.html
@@ -70,7 +70,8 @@
             <div class="progress-step"></div>
           </div>
           <form id="sell-form">
-            <div class="form-step current-step">
+            <!-- Step 1: User Info -->
+            <div class="form-step current-step" data-step="1">
               <div class="field-group">
                 <label for="name">Nombre</label>
                 <input type="text" id="name" name="name" required />
@@ -79,18 +80,30 @@
                 <label for="email">Email</label>
                 <input type="email" id="email" name="email" required />
               </div>
+              <div class="field-group">
+                <label for="city">Ciudad</label>
+                <input type="text" id="city" name="city" required />
+              </div>
               <div class="buttons">
                 <button type="button" class="next-button">Siguiente</button>
               </div>
             </div>
-            <div class="form-step">
+
+            <!-- Step 2: Book Count -->
+            <div class="form-step" data-step="2">
               <div class="field-group">
-                <label for="title">Título del libro</label>
-                <input type="text" id="title" name="title" required />
-              </div>
-              <div class="field-group">
-                <label for="author">Autor</label>
-                <input type="text" id="author" name="author" required />
+                <label for="book-count">Cantidad de libros</label>
+                <input
+                  type="number"
+                  id="book-count"
+                  name="book-count"
+                  min="1"
+                  max="50"
+                  required
+                />
+                <small>
+                  Te vamos a pedir una foto y algunos datos para cada libro
+                </small>
               </div>
               <div class="buttons">
                 <button type="button" class="prev-button">Anterior</button>
@@ -98,56 +111,24 @@
               </div>
             </div>
 
-            <!-- Step 3 – Delivery & Location -->
-            <div class="form-step" data-step="3" hidden>
-              <h2>Entrega y ubicación</h2>
-              <label for="zone">Zona</label>
-              <input type="text" id="zone" name="zone" required />
-
-              <fieldset>
-                <legend>Entrega</legend>
-                <label for="bring">
-                  <input
-                    type="radio"
-                    id="bring"
-                    name="delivery"
-                    value="bring"
-                    checked
-                  />
-                  Lo acerco
-                </label>
-                <label for="pickup">
-                  <input
-                    type="radio"
-                    id="pickup"
-                    name="delivery"
-                    value="pickup"
-                  />
-                  Quiero que lo retiren
-                </label>
-              </fieldset>
-
-              <label for="availability">Disponibilidad</label>
-              <textarea id="availability" name="availability"></textarea>
-
-              <div class="form-navigation">
+            <!-- Step 3: Book Details -->
+            <div class="form-step" data-step="3">
+              <div id="book-steps"></div>
+              <div class="buttons">
                 <button type="button" class="prev-button">Anterior</button>
                 <button type="button" class="next-button">Siguiente</button>
               </div>
             </div>
 
-            <!-- Step 4 – Confirmation -->
-            <div class="form-step" data-step="4" hidden>
+            <!-- Step 4: Confirmation -->
+            <div class="form-step" data-step="4">
               <h2>Confirmación</h2>
-              <div class="review-data">
-                <!-- datos ingresados -->
-              </div>
+              <div id="summary"></div>
               <label for="terms" class="terms">
-                <input type="checkbox" id="terms" required /> Acepto términos y
-                condiciones
+                <input type="checkbox" id="terms" required /> Acepto los
+                términos y condiciones
               </label>
-
-              <div class="form-navigation">
+              <div class="buttons">
                 <button type="button" class="prev-button">Anterior</button>
                 <button type="submit" class="submit-button">Enviar</button>
               </div>


### PR DESCRIPTION
## Summary
- modernize the sell form with a 4‑step wizard
- generate book fields dynamically based on quantity
- show a confirmation summary before sending
- style submit button and book fieldsets
- display a success message at the end

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a2ab2dcc4832289e53914ad6d717b