### PR TITLE
Add image upload preview and progress

### DIFF
--- a/public/styles/vende.css
+++ b/public/styles/vende.css
@@ -293,3 +293,26 @@
   color: #e74c3c;
   font-size: 0.875rem;
 }
+
+.photo-preview {
+  max-width: 150px;
+  margin-top: 5px;
+  display: block;
+}
+
+.progress-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 5px;
+}
+
+.retry-upload {
+  margin-top: 5px;
+  background: transparent;
+  border: 1px solid #112a4a;
+  color: #112a4a;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- allow retry and progress on image upload
- upload images to firebase storage with `uploadBytesResumable`
- show preview thumbnails and progress bars during book upload
- style photo preview and upload controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a3a3db21483229af99a6d44282bfc