### PR TITLE
Improve vendé form feedback

### DIFF
--- a/public/styles/vende.css
+++ b/public/styles/vende.css
@@ -316,3 +316,24 @@
   border-radius: 4px;
   cursor: pointer;
 }
+
+.form-feedback {
+  text-align: center;
+  margin-top: 20px;
+}
+
+.form-success {
+  color: #112a4a;
+  font-size: 1.2rem;
+  padding: 20px 0;
+}
+
+.form-error {
+  color: #e74c3c;
+  font-size: 1rem;
+  margin-top: 10px;
+}
+
+.loading-message {
+  color: #112a4a;
+}

--- a/src/form.js
+++ b/src/form.js
@@ -2,6 +2,7 @@
 document.addEventListener('DOMContentLoaded', function () {
   const formSection = document.getElementById('form');
   const form = document.getElementById('sell-form');
+  const feedback = document.getElementById('form-feedback');
   if (formSection) {
     formSection.classList.add('hidden');
   }
@@ -446,6 +447,11 @@ document.addEventListener('DOMContentLoaded', function () {
       submitBtn.disabled = true;
       submitBtn.textContent = 'Enviando...';
     }
+    if (feedback) {
+      feedback.textContent = 'Enviando...';
+      feedback.className = 'form-feedback loading-message';
+      feedback.classList.remove('hidden');
+    }
 
     const uploadPromises = [];
     for (let i = 1; i <= books.length; i++) {
@@ -471,6 +477,22 @@ document.addEventListener('DOMContentLoaded', function () {
       if (submitBtn) {
         submitBtn.disabled = false;
         submitBtn.textContent = 'Enviar';
+      }
+      if (feedback) {
+        feedback.innerHTML =
+          '<p>Error al subir las fotos. Intentá nuevamente.</p>';
+        const retry = document.createElement('button');
+        retry.type = 'button';
+        retry.textContent = 'Reintentar';
+        retry.className = 'retry-submit';
+        retry.addEventListener('click', function () {
+          feedback.classList.add('hidden');
+          form.requestSubmit();
+        });
+        feedback.appendChild(retry);
+        feedback.className = 'form-feedback form-error';
+        feedback.classList.remove('hidden');
+        feedback.scrollIntoView({ behavior: 'smooth' });
       }
       return;
     }
@@ -513,13 +535,33 @@ document.addEventListener('DOMContentLoaded', function () {
       } catch (err) {
         console.warn('sendConfirmationEmail failed', err);
       }
-      form.innerHTML =
-        '<p class="success-message">\u00a1Gracias! Nos vamos a estar comunicando con vos por mail.</p>';
+      form.classList.add('hidden');
+      if (feedback) {
+        feedback.textContent =
+          '\u00a1Gracias! Nos estaremos comunicando con vos por mail.';
+        feedback.className = 'form-feedback form-success';
+        feedback.classList.remove('hidden');
+        feedback.scrollIntoView({ behavior: 'smooth' });
+      }
     } catch (err) {
       console.error('Error saving form', err);
-      alert(
-        'Ocurri\u00f3 un problema al enviar el formulario. Intentalo nuevamente.',
-      );
+      if (feedback) {
+        feedback.innerHTML =
+          '<p>Ocurri\u00f3 un problema al enviar el formulario.</p>';
+        const retry = document.createElement('button');
+        retry.type = 'button';
+        retry.textContent = 'Reintentar';
+        retry.className = 'retry-submit';
+        retry.addEventListener('click', function () {
+          feedback.classList.add('hidden');
+          form.classList.remove('hidden');
+          form.requestSubmit();
+        });
+        feedback.appendChild(retry);
+        feedback.className = 'form-feedback form-error';
+        feedback.classList.remove('hidden');
+        feedback.scrollIntoView({ behavior: 'smooth' });
+      }
       if (submitBtn) {
         submitBtn.disabled = false;
         submitBtn.textContent = 'Enviar';

--- a/src/vende.html
+++ b/src/vende.html
@@ -141,6 +141,7 @@
               </div>
             </div>
           </form>
+          <div id="form-feedback" class="form-feedback hidden"></div>
         </section>
         <!-- Testimonials section -->
         <section class="testimonials"></section>


### PR DESCRIPTION
## Summary
- add persistent feedback container to vendé form
- style loading, success and error messages
- show loading message and disable form on submit
- display success or error with retry option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a41ba72a88322b8b013510b484d09