### PR TITLE
Add overlay animation for sell form

### DIFF
--- a/public/styles/vende.css
+++ b/public/styles/vende.css
@@ -10,6 +10,15 @@
   display: none;
 }
 
+body.show-form {
+  overflow: hidden;
+}
+
+body.show-form main {
+  filter: blur(4px);
+  transition: filter 0.3s ease;
+}
+
 .hero {
   padding: 40px 20px;
   background: #f4f4f4;
@@ -133,6 +142,25 @@
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   margin-bottom: 40px;
+}
+
+.form-wizard.overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 100%;
+  max-width: 600px;
+  margin: 0;
+  border-radius: 0;
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+}
+
+body.show-form .form-wizard.overlay {
+  transform: translateX(0);
 }
 
 .progress-indicator {
@@ -336,4 +364,14 @@
 
 .loading-message {
   color: #112a4a;
+}
+
+.close-form {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
 }

--- a/src/form.js
+++ b/src/form.js
@@ -13,11 +13,34 @@ document.addEventListener('DOMContentLoaded', function () {
     formSection.classList.add('hidden');
   }
 
+  function openForm() {
+    if (formSection) {
+      formSection.classList.remove('hidden');
+      document.body.classList.add('show-form');
+    }
+  }
+
+  function closeForm() {
+    document.body.classList.remove('show-form');
+    if (formSection) {
+      formSection.classList.add('hidden');
+    }
+    if (feedback) {
+      feedback.classList.add('hidden');
+    }
+  }
+
   const startButton = document.querySelector('[data-scroll-to="form"]');
   if (startButton && formSection) {
     startButton.addEventListener('click', function () {
-      formSection.classList.remove('hidden');
-      formSection.scrollIntoView({ behavior: 'smooth' });
+      openForm();
+    });
+  }
+
+  const closeButton = document.querySelector('#form .close-form');
+  if (closeButton) {
+    closeButton.addEventListener('click', function () {
+      closeForm();
     });
   }
 
@@ -562,6 +585,7 @@ document.addEventListener('DOMContentLoaded', function () {
         feedback.classList.remove('hidden');
         feedback.scrollIntoView({ behavior: 'smooth' });
       }
+      setTimeout(closeForm, 2000);
     } catch (err) {
       logError('Error saving form', err);
       if (feedback) {

--- a/src/vende.html
+++ b/src/vende.html
@@ -62,7 +62,10 @@
           </div>
         </section>
         <!-- Multistep form -->
-        <section class="form-wizard hidden" id="form">
+        <section class="form-wizard overlay hidden" id="form">
+          <button type="button" class="close-form" aria-label="Cerrar">
+            ×
+          </button>
           <div class="progress-indicator">
             <div class="progress-step"></div>
             <div class="progress-step"></div>


### PR DESCRIPTION
## Summary
- slide "Vendé" form in from the right instead of scrolling
- blur background when the form is visible
- allow closing the form and auto-hide on submit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a64262d8483229625859c9d50e8fe